### PR TITLE
fix: change logic for missing classes secret to log error instead of not creating pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/influxdata/telegraf-operator
 go 1.13
 
 require (
+	github.com/go-logr/logr v0.1.0
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad

--- a/handler.go
+++ b/handler.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/go-logr/logr"
 	admv1 "k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -36,6 +37,7 @@ type podInjector struct {
 	client  client.Client
 	decoder *admission.Decoder
 	names.NameGenerator
+	Logger                    logr.Logger
 	TelegrafClassesSecretName string
 	TelegrafDefaultClass      string
 	ControllerNamespace       string
@@ -78,31 +80,37 @@ func (a *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 	if skip(pod) {
 		return admission.Allowed("telegraf-injector has no power over this pod")
 	}
-	classData, err := a.getClassData(pod)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
+
 	name := pod.GetName()
 	if name == "" {
 		name = names.SimpleNameGenerator.GenerateName(pod.GetGenerateName())
 		pod.SetName(name)
 		handlerLog.Info("name: " + name + ",  pod_getname=" + pod.GetName())
 	}
-	secret, err := addSidecar(pod, pod.GetName(), req.Namespace, classData)
-	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-	if req.Operation == admv1.Create {
-		err = a.client.Create(ctx, secret)
+
+	classData, err := a.getClassData(pod)
+	if err == nil {
+		a.Logger.Info("class data found ; adding sidecar container")
+		// if the class was found, add sidecar
+		secret, err := addSidecar(pod, pod.GetName(), req.Namespace, classData)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-	}
-	if req.Operation == admv1.Update {
-		err = a.client.Update(ctx, secret)
-		if err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+
+		if req.Operation == admv1.Create {
+			err = a.client.Create(ctx, secret)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
 		}
+		if req.Operation == admv1.Update {
+			err = a.client.Update(ctx, secret)
+			if err != nil {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+		}
+	} else {
+		a.Logger.Info(fmt.Sprintf("unable to find class data: %v ; not adding sidecar container", err))
 	}
 
 	marshaledPod, err := json.Marshal(pod)

--- a/handler.go
+++ b/handler.go
@@ -78,6 +78,7 @@ func (a *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 	if skip(pod) {
+		a.Logger.Info("skipping pod as telegraf-injector should not handle it")
 		return admission.Allowed("telegraf-injector has no power over this pod")
 	}
 
@@ -89,28 +90,29 @@ func (a *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 	}
 
 	classData, err := a.getClassData(pod)
-	if err == nil {
-		a.Logger.Info("class data found ; adding sidecar container")
-		// if the class was found, add sidecar
-		secret, err := addSidecar(pod, pod.GetName(), req.Namespace, classData)
+	if err != nil {
+		a.Logger.Info(fmt.Sprintf("unable to find class data: %v ; not adding sidecar container", err))
+		return admission.Allowed("telegraf-injector could not create sidecar container")
+	}
+
+	a.Logger.Info("class data found ; adding sidecar container")
+	// if the class was found, add sidecar
+	secret, err := addSidecar(pod, pod.GetName(), req.Namespace, classData)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if req.Operation == admv1.Create {
+		err = a.client.Create(ctx, secret)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-
-		if req.Operation == admv1.Create {
-			err = a.client.Create(ctx, secret)
-			if err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
+	}
+	if req.Operation == admv1.Update {
+		err = a.client.Update(ctx, secret)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if req.Operation == admv1.Update {
-			err = a.client.Update(ctx, secret)
-			if err != nil {
-				return admission.Errored(http.StatusBadRequest, err)
-			}
-		}
-	} else {
-		a.Logger.Info(fmt.Sprintf("unable to find class data: %v ; not adding sidecar container", err))
 	}
 
 	marshaledPod, err := json.Marshal(pod)

--- a/handler.go
+++ b/handler.go
@@ -92,7 +92,7 @@ func (a *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 	classData, err := a.getClassData(pod)
 	if err != nil {
 		a.Logger.Info(fmt.Sprintf("unable to find class data: %v ; not adding sidecar container", err))
-		return admission.Allowed("telegraf-injector could not create sidecar container")
+		return admission.Allowed("telegraf-operator could not create sidecar container")
 	}
 
 	a.Logger.Info("class data found ; adding sidecar container")

--- a/handler_test.go
+++ b/handler_test.go
@@ -240,11 +240,7 @@ func Test_podInjector_Handle(t *testing.T) {
 			},
 			want: want{
 				Allowed: true,
-				Patches: []string{
-					`{"op":"add","path":"/metadata/creationTimestamp"}`,
-					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/status","value":{}}`,
-				},
+				Code:    http.StatusOK,
 			},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func main() {
 		TelegrafClassesSecretName: telegrafClassesSecretName,
 		TelegrafDefaultClass:      defaultTelegrafClass,
 		ControllerNamespace:       controllerNamespace,
+		Logger:                    setupLog.WithName("podInjector"),
 	}})
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
Closes #12

This changes how handling errors related to retrieving secret classes is handled to only log the error and not create sidecar instead of returning and error, as this prevents the pods to from being created at all.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
