### PR TITLE
fix: add useful and more practical classes to examples/classes.yml

### DIFF
--- a/examples/classes.yml
+++ b/examples/classes.yml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: telegraf-injector-classes
-  namespace: telegraf-injector
+  name: telegraf-operator-classes
+  namespace: telegraf-operator
 stringData:
-  infra: |+
+  acc: |+
     [[outputs.influxdb_v2]]
       urls = ["zzzzzzz"]
       token = "zzzzzz"
@@ -20,7 +20,7 @@ stringData:
       metric_batch_size = 100000
       metric_buffer_limit = 100000
       collection_jitter = "0s"
-  app: |+
+  influxdb_v2: |+
     [[outputs.influxdb_v2]]
       urls = ["xxxxxx"]
       token = "xxxxxxx"
@@ -32,9 +32,29 @@ stringData:
     [global_tags]
       hostname = "$HOSTNAME"
       nodename = "$NODENAME"
-  basic: |+
+  app: |+
     [[outputs.influxdb]]
       urls = ["http://influxdb.influxdb:8086"]
+    [[outputs.file]]
+      files = ["stdout"]
     [global_tags]
       hostname = "$HOSTNAME"
       nodename = "$NODENAME"
+      type = "app"
+  basic: |+
+    [[outputs.influxdb]]
+      urls = ["http://influxdb.influxdb:8086"]
+    [[outputs.file]]
+      files = ["stdout"]
+    [global_tags]
+      hostname = "$HOSTNAME"
+      nodename = "$NODENAME"
+  infra: |+
+    [[outputs.influxdb]]
+      urls = ["http://influxdb.influxdb:8086"]
+    [[outputs.file]]
+      files = ["stdout"]
+    [global_tags]
+      hostname = "$HOSTNAME"
+      nodename = "$NODENAME"
+      type = "infra"


### PR DESCRIPTION
While working with `telegraf-operator`, I have noticed that the default `classes.yml` does not make it easy to troubleshoot.

What I've done is made `basic`, `app` and `infra` log to influxDB 1.x as well as to stdout and renamed the examples that are using InfluxDB 2.0 as we do not have a ready to run example for InfluxDB 2.0.

I also found that logging data to stdout makes it easier to get started as I can see the outputs immediately.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
