### PR TITLE
feat: add support for customizing telegraf image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The available annotions are:
 - `telegraf.influxdata.com/interval` : is used to configure interval for telegraf scraping (Go style duration, e.g 5s, 30s, 2m .. )
 - `telegraf.influxdata.com/inputs` : is used to configure custom inputs for telegraf
 - `telegraf.influxdata.com/internal` : is used to enable telegraf "internal" input plugins for
+- `telegraf.influxdata.com/image` : is used to configure telegraf image to be used for the `telegraf` sidecar container
 - `telegraf.influxdata.com/class` : configures which kind of class to use (classes are configured on the operator)
 - `telegraf.influxdata.com/secret-env` : allows adding secrets to the telegraf sidecar in the form of environment variables
 

--- a/handler.go
+++ b/handler.go
@@ -40,6 +40,7 @@ type podInjector struct {
 	Logger                    logr.Logger
 	TelegrafClassesSecretName string
 	TelegrafDefaultClass      string
+	TelegrafImage             string
 	ControllerNamespace       string
 }
 
@@ -103,7 +104,7 @@ func (a *podInjector) Handle(ctx context.Context, req admission.Request) admissi
 
 	a.Logger.Info("adding sidecar container")
 	// if the telegraf configuration could be created, add sidecar pod
-	secret, err := addSidecar(pod, pod.GetName(), req.Namespace, telegrafConf)
+	secret, err := addSidecar(pod, a.TelegrafImage, pod.GetName(), req.Namespace, telegrafConf)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -379,7 +379,7 @@ func Test_podInjector_Handle(t *testing.T) {
 			},
 			objects: []runtime.Object{
 				&corev1.Secret{
-					Data: map[string][]byte{TelegrafClass: []byte("value")},
+					Data: map[string][]byte{TelegrafClass: []byte(sampleClassData)},
 				},
 			},
 			want: want{

--- a/handler_test.go
+++ b/handler_test.go
@@ -334,7 +334,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.12","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.13","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -443,7 +443,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.12","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.13","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},

--- a/handler_test.go
+++ b/handler_test.go
@@ -138,6 +138,7 @@ func Test_podInjector_getClassData(t *testing.T) {
 				TelegrafClassesSecretName: tt.secretName,
 				TelegrafDefaultClass:      tt.className,
 				ControllerNamespace:       tt.namespace,
+				TelegrafImage:             defaultTelegrafImage,
 				Logger:                    &logrTesting.TestLogger{T: t},
 			}
 			got, err := p.getClassData(tt.pod)
@@ -340,6 +341,59 @@ func Test_podInjector_Handle(t *testing.T) {
 			},
 		},
 		{
+			name: "inject telegraf with custom image into container",
+			req: admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{
+					Operation: admv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte(`{
+								"apiVersion": "v1",
+								"kind": "Pod",
+								"metadata": {
+								  "name": "simple",
+								  "annotations": {
+									"telegraf.influxdata.com/port": "8080",
+									"telegraf.influxdata.com/path": "/v1/metrics",
+									"telegraf.influxdata.com/interval": "5s",
+									"telegraf.influxdata.com/image": "docker.io/library/telegraf:1.11"
+								  }
+								},
+								"spec": {
+								  "containers": [
+									{
+									  "name": "busybox",
+									  "image": "busybox",
+									  "args": [
+										"sleep",
+										"1000000"
+									  ]
+									}
+								  ]
+								}
+							  }`),
+					},
+				},
+			},
+			fields: fields{
+				TelegrafDefaultClass: TelegrafClass,
+			},
+			objects: []runtime.Object{
+				&corev1.Secret{
+					Data: map[string][]byte{TelegrafClass: []byte("value")},
+				},
+			},
+			want: want{
+				Allowed: true,
+				Patches: []string{
+					`{"op":"add","path":"/metadata/creationTimestamp"}`,
+					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
+					`{"op":"add","path":"/status","value":{}}`,
+				},
+			},
+		},
+		{
 			name: "update telegraf container on inject",
 			req: admission.Request{
 				AdmissionRequest: admv1.AdmissionRequest{
@@ -433,6 +487,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				client:               client,
 				decoder:              decoder,
 				TelegrafDefaultClass: tt.fields.TelegrafDefaultClass,
+				TelegrafImage:        defaultTelegrafImage,
 				Logger:               &logrTesting.TestLogger{T: t},
 			}
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,10 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	defaultTelegrafImage = "docker.io/library/telegraf:1.12"
+)
+
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
@@ -49,12 +53,14 @@ func main() {
 	var telegrafClassesSecretName string
 	var defaultTelegrafClass string
 	var controllerNamespace string
+	var telegrafImage string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&telegrafClassesSecretName, "telegraf-classes-secret", "telegraf-classes", "The name of the secret in which are configured the telegraf classes")
 	flag.StringVar(&defaultTelegrafClass, "telegraf-default-class", "default", "Default telegraf class to use")
 	flag.StringVar(&controllerNamespace, "namespace", os.Getenv("POD_NAMESPACE"), "Namespace in whick this pod is running in")
+	flag.StringVar(&telegrafImage, "telegraf-image", defaultTelegrafImage, "Telegraf image to inject")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -84,6 +90,7 @@ func main() {
 	hookServer.Register("/mutate-v1-pod", &webhook.Admission{Handler: &podInjector{
 		TelegrafClassesSecretName: telegrafClassesSecretName,
 		TelegrafDefaultClass:      defaultTelegrafClass,
+		TelegrafImage:             telegrafImage,
 		ControllerNamespace:       controllerNamespace,
 		Logger:                    setupLog.WithName("podInjector"),
 	}})

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 const (
-	defaultTelegrafImage = "docker.io/library/telegraf:1.12"
+	defaultTelegrafImage = "docker.io/library/telegraf:1.13"
 )
 
 func init() {

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -296,40 +296,6 @@ status: {}
 			}
 		})
 	}
-
-	// 	got = toYAML(t, pod)
-	// 	want = `metadata:
-	//   annotations:
-	//     telegraf.influxdata.com/ports: "6060"
-	//   creationTimestamp: null
-	// spec:
-	//   containers:
-	//   - env:
-	//     - name: NODENAME
-	//       valueFrom:
-	//         fieldRef:
-	//           fieldPath: spec.nodeName
-	//     image: docker.io/library/telegraf:1.12
-	//     name: telegraf
-	//     resources:
-	//       limits:
-	//         cpu: 500m
-	//         memory: 500Mi
-	//       requests:
-	//         cpu: 50m
-	//         memory: 50Mi
-	//     volumeMounts:
-	//     - mountPath: /etc/telegraf
-	//       name: telegraf-config
-	//   volumes:
-	//   - name: telegraf-config
-	//     secret:
-	//       secretName: telegraf-config-myname
-	// status: {}
-	// `
-	// 	if got != want {
-	// 		t.Errorf("unexpected pod got:\n%v\nwant:\n%v", got, want)
-	// 	}
 }
 
 func Test_ports(t *testing.T) {

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -210,7 +210,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.12
+    image: docker.io/library/telegraf:1.13
     name: telegraf
     resources:
       limits:

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -166,25 +167,22 @@ func Test_assembleConf(t *testing.T) {
 }
 
 func Test_addSidecar(t *testing.T) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				TelegrafMetricsPorts: "6060",
+	tests := []struct {
+		name       string
+		pod        *corev1.Pod
+		wantSecret string
+		wantPod    string
+	}{
+		{
+			name: "validate prometheus inputs creation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						TelegrafMetricsPorts: "6060",
+					},
+				},
 			},
-		},
-	}
-
-	telegrafConf, err := assembleConf(pod, "")
-	if err != nil {
-		t.Errorf("unexpected error assembling sidecar configuration: %v", err)
-	}
-	secret, err := addSidecar(pod, "myname", "mynamespace", telegrafConf)
-	if err != nil {
-		t.Errorf("unexpected error adding to sidecar: %v", err)
-	}
-
-	got := toYAML(t, secret)
-	want := `apiVersion: v1
+			wantSecret: `apiVersion: v1
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -193,17 +191,17 @@ metadata:
 stringData:
   telegraf.conf: "\n[[inputs.prometheus]]\n  urls = [\"http://127.0.0.1:6060/metrics\"]\n
     \ \n\n"
-type: Opaque
-`
-
-	if got != want {
-		t.Errorf("unexpected secret got:\n%v\nwant:\n%v", got, want)
-	}
-
-	got = toYAML(t, pod)
-	want = `metadata:
-  annotations:
-    telegraf.influxdata.com/ports: "6060"
+type: Opaque`,
+		},
+		{
+			name: "validate default telegraf pod definition",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			wantPod: `
+metadata:
   creationTimestamp: null
 spec:
   containers:
@@ -229,10 +227,109 @@ spec:
     secret:
       secretName: telegraf-config-myname
 status: {}
-`
-	if got != want {
-		t.Errorf("unexpected pod got:\n%v\nwant:\n%v", got, want)
+			`,
+		},
+		{
+			name: "validate custom telegraf image pod definition",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						TelegrafImage: "docker.io/library/telegraf:1.11",
+					},
+				},
+			},
+			wantPod: `
+metadata:
+  annotations:
+    telegraf.influxdata.com/image: docker.io/library/telegraf:1.11
+  creationTimestamp: null
+spec:
+  containers:
+  - env:
+    - name: NODENAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    image: docker.io/library/telegraf:1.11
+    name: telegraf
+    resources:
+      limits:
+        cpu: 500m
+        memory: 500Mi
+      requests:
+        cpu: 50m
+        memory: 50Mi
+    volumeMounts:
+    - mountPath: /etc/telegraf
+      name: telegraf-config
+  volumes:
+  - name: telegraf-config
+    secret:
+      secretName: telegraf-config-myname
+status: {}
+			`,
+		},
 	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			telegrafConf, err := assembleConf(tt.pod, "")
+			if err != nil {
+				t.Errorf("unexpected error assembling sidecar configuration: %v", err)
+			}
+			secret, err := addSidecar(tt.pod, defaultTelegrafImage, "myname", "mynamespace", telegrafConf)
+			if err != nil {
+				t.Errorf("unexpected error adding to sidecar: %v", err)
+			}
+
+			if tt.wantSecret != "" {
+				if want, got := strings.TrimSpace(tt.wantSecret), strings.TrimSpace(toYAML(t, secret)); got != want {
+					t.Errorf("unexpected secret got:\n%v\nwant:\n%v", got, want)
+				}
+			}
+
+			if tt.wantPod != "" {
+				if want, got := strings.TrimSpace(tt.wantPod), strings.TrimSpace(toYAML(t, tt.pod)); got != want {
+					fmt.Printf("WTF\n%s\n", got)
+					t.Errorf("unexpected pod got:\n%v\nwant:\n%v", got, want)
+				}
+			}
+		})
+	}
+
+	// 	got = toYAML(t, pod)
+	// 	want = `metadata:
+	//   annotations:
+	//     telegraf.influxdata.com/ports: "6060"
+	//   creationTimestamp: null
+	// spec:
+	//   containers:
+	//   - env:
+	//     - name: NODENAME
+	//       valueFrom:
+	//         fieldRef:
+	//           fieldPath: spec.nodeName
+	//     image: docker.io/library/telegraf:1.12
+	//     name: telegraf
+	//     resources:
+	//       limits:
+	//         cpu: 500m
+	//         memory: 500Mi
+	//       requests:
+	//         cpu: 50m
+	//         memory: 50Mi
+	//     volumeMounts:
+	//     - mountPath: /etc/telegraf
+	//       name: telegraf-config
+	//   volumes:
+	//   - name: telegraf-config
+	//     secret:
+	//       secretName: telegraf-config-myname
+	// status: {}
+	// `
+	// 	if got != want {
+	// 		t.Errorf("unexpected pod got:\n%v\nwant:\n%v", got, want)
+	// 	}
 }
 
 func Test_ports(t *testing.T) {


### PR DESCRIPTION
Closes #11

Allows passing telegraf image as command line option as well as using an annotation.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
