### PR TITLE
feat: add --enable-default-internal-plugin to enable inputs.internal globally

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -84,6 +84,7 @@ spec:
       containers:
         - name: controller
           image: quay.io/influxdb/telegraf-operator:latest
+          imagePullPolicy: IfNotPresent
           args:
             - --telegraf-default-class=basic
             - --telegraf-classes-secret=telegraf-operator-classes

--- a/handler_test.go
+++ b/handler_test.go
@@ -139,7 +139,7 @@ func Test_podInjector_getClassData(t *testing.T) {
 				TelegrafDefaultClass:      tt.className,
 				ControllerNamespace:       tt.namespace,
 				Logger:                    &logrTesting.TestLogger{T: t},
-				SidecarConfig: &sidecarConfig{
+				SidecarHandler: &sidecarHandler{
 					TelegrafImage: defaultTelegrafImage,
 				},
 			}
@@ -172,7 +172,7 @@ func Test_podInjector_Handle(t *testing.T) {
 		objects []runtime.Object
 		req     admission.Request
 		want    want
-		config  *sidecarConfig
+		handler *sidecarHandler
 	}{
 		{
 			name: "error if no pod in request",
@@ -376,7 +376,7 @@ func Test_podInjector_Handle(t *testing.T) {
 					},
 				},
 			},
-			config: &sidecarConfig{
+			handler: &sidecarHandler{
 				TelegrafImage: "docker.io/library/telegraf:1.11",
 			},
 			fields: fields{
@@ -541,12 +541,12 @@ func Test_podInjector_Handle(t *testing.T) {
 				t.Fatalf("unable to create decoder: %v", err)
 			}
 
-			if tt.config == nil {
-				tt.config = &sidecarConfig{}
+			if tt.handler == nil {
+				tt.handler = &sidecarHandler{}
 			}
 
-			if tt.config.TelegrafImage == "" {
-				tt.config.TelegrafImage = defaultTelegrafImage
+			if tt.handler.TelegrafImage == "" {
+				tt.handler.TelegrafImage = defaultTelegrafImage
 			}
 
 			p := &podInjector{
@@ -554,7 +554,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				decoder:              decoder,
 				TelegrafDefaultClass: tt.fields.TelegrafDefaultClass,
 				Logger:               &logrTesting.TestLogger{T: t},
-				SidecarConfig:        tt.config,
+				SidecarHandler:       tt.handler,
 			}
 
 			resp := p.Handle(context.Background(), tt.req)

--- a/handler_test.go
+++ b/handler_test.go
@@ -138,8 +138,10 @@ func Test_podInjector_getClassData(t *testing.T) {
 				TelegrafClassesSecretName: tt.secretName,
 				TelegrafDefaultClass:      tt.className,
 				ControllerNamespace:       tt.namespace,
-				TelegrafImage:             defaultTelegrafImage,
 				Logger:                    &logrTesting.TestLogger{T: t},
+				SidecarConfig: &sidecarConfig{
+					TelegrafImage: defaultTelegrafImage,
+				},
 			}
 			got, err := p.getClassData(tt.pod)
 			if (err != nil) != tt.wantErr {
@@ -170,6 +172,7 @@ func Test_podInjector_Handle(t *testing.T) {
 		objects []runtime.Object
 		req     admission.Request
 		want    want
+		config  *sidecarConfig
 	}{
 		{
 			name: "error if no pod in request",
@@ -341,6 +344,61 @@ func Test_podInjector_Handle(t *testing.T) {
 			},
 		},
 		{
+			name: "inject telegraf with custom image passed as sidecar config into container",
+			req: admission.Request{
+				AdmissionRequest: admv1.AdmissionRequest{
+					Operation: admv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte(`{
+								"apiVersion": "v1",
+								"kind": "Pod",
+								"metadata": {
+								  "name": "simple",
+								  "annotations": {
+									"telegraf.influxdata.com/port": "8080",
+									"telegraf.influxdata.com/path": "/v1/metrics",
+									"telegraf.influxdata.com/interval": "5s"
+								  }
+								},
+								"spec": {
+								  "containers": [
+									{
+									  "name": "busybox",
+									  "image": "busybox",
+									  "args": [
+										"sleep",
+										"1000000"
+									  ]
+									}
+								  ]
+								}
+							  }`),
+					},
+				},
+			},
+			config: &sidecarConfig{
+				TelegrafImage: "docker.io/library/telegraf:1.11",
+			},
+			fields: fields{
+				TelegrafDefaultClass: TelegrafClass,
+			},
+			objects: []runtime.Object{
+				&corev1.Secret{
+					Data: map[string][]byte{TelegrafClass: []byte(sampleClassData)},
+				},
+			},
+			want: want{
+				Allowed: true,
+				Patches: []string{
+					`{"op":"add","path":"/metadata/creationTimestamp"}`,
+					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"500m","memory":"500Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
+					`{"op":"add","path":"/status","value":{}}`,
+				},
+			},
+		},
+		{
 			name: "inject telegraf with custom image into container",
 			req: admission.Request{
 				AdmissionRequest: admv1.AdmissionRequest{
@@ -483,12 +541,20 @@ func Test_podInjector_Handle(t *testing.T) {
 				t.Fatalf("unable to create decoder: %v", err)
 			}
 
+			if tt.config == nil {
+				tt.config = &sidecarConfig{}
+			}
+
+			if tt.config.TelegrafImage == "" {
+				tt.config.TelegrafImage = defaultTelegrafImage
+			}
+
 			p := &podInjector{
 				client:               client,
 				decoder:              decoder,
 				TelegrafDefaultClass: tt.fields.TelegrafDefaultClass,
-				TelegrafImage:        defaultTelegrafImage,
 				Logger:               &logrTesting.TestLogger{T: t},
+				SidecarConfig:        tt.config,
 			}
 
 			resp := p.Handle(context.Background(), tt.req)

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 		TelegrafDefaultClass:      defaultTelegrafClass,
 		ControllerNamespace:       controllerNamespace,
 		Logger:                    setupLog.WithName("podInjector"),
-		SidecarConfig: &sidecarConfig{
+		SidecarHandler: &sidecarHandler{
 			TelegrafImage:               telegrafImage,
 			EnableDefaultInternalPlugin: enableDefaultInternalPlugin,
 		},

--- a/sidecar.go
+++ b/sidecar.go
@@ -40,13 +40,13 @@ const (
 	telegrafSecretPrefix = "telegraf-config"
 )
 
-type sidecarConfig struct {
+type sidecarHandler struct {
 	TelegrafImage               string
 	EnableDefaultInternalPlugin bool
 }
 
 // This function check if the pod have the correct annotations, otherwise the controller will skip this pod entirely
-func skip(pod *corev1.Pod) bool {
+func (h *sidecarHandler) skip(pod *corev1.Pod) bool {
 	for key := range pod.GetAnnotations() {
 		if strings.Contains(key, TelegrafAnnotationCommon) {
 			return false
@@ -55,14 +55,14 @@ func skip(pod *corev1.Pod) bool {
 	return true
 }
 
-func addSidecar(pod *corev1.Pod, config *sidecarConfig, name, namespace, telegrafConf string) (*corev1.Secret, error) {
-	pod.Spec.Containers = append(pod.Spec.Containers, newContainer(pod, config))
-	pod.Spec.Volumes = append(pod.Spec.Volumes, newVolume(name))
-	return newSecret(pod, name, namespace, telegrafConf)
+func (h *sidecarHandler) addSidecar(pod *corev1.Pod, name, namespace, telegrafConf string) (*corev1.Secret, error) {
+	pod.Spec.Containers = append(pod.Spec.Containers, h.newContainer(pod))
+	pod.Spec.Volumes = append(pod.Spec.Volumes, h.newVolume(name))
+	return h.newSecret(pod, name, namespace, telegrafConf)
 }
 
 // Assembling telegraf configuration
-func assembleConf(pod *corev1.Pod, config *sidecarConfig, classData string) (telegrafConf string, err error) {
+func (h *sidecarHandler) assembleConf(pod *corev1.Pod, classData string) (telegrafConf string, err error) {
 	ports := ports(pod)
 	if len(ports) != 0 {
 		path := "/metrics"
@@ -86,7 +86,7 @@ func assembleConf(pod *corev1.Pod, config *sidecarConfig, classData string) (tel
 			telegrafConf = fmt.Sprintf("%s\n%s", telegrafConf, fmt.Sprintf("[[inputs.prometheus]]\n  urls = [\"%s\"]\n  %s\n", strings.Join(urls, `", "`), intervalConfig))
 		}
 	}
-	enableInternal := config.EnableDefaultInternalPlugin
+	enableInternal := h.EnableDefaultInternalPlugin
 	if internalRaw, ok := pod.Annotations[TelegrafEnableInternal]; ok {
 		internal, err := strconv.ParseBool(internalRaw)
 		if err != nil {
@@ -111,7 +111,7 @@ func assembleConf(pod *corev1.Pod, config *sidecarConfig, classData string) (tel
 	return telegrafConf, err
 }
 
-func newSecret(pod *corev1.Pod, name, namespace, telegrafConf string) (*corev1.Secret, error) {
+func (h *sidecarHandler) newSecret(pod *corev1.Pod, name, namespace, telegrafConf string) (*corev1.Secret, error) {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -128,7 +128,7 @@ func newSecret(pod *corev1.Pod, name, namespace, telegrafConf string) (*corev1.S
 	}, nil
 }
 
-func newVolume(name string) corev1.Volume {
+func (h *sidecarHandler) newVolume(name string) corev1.Volume {
 	return corev1.Volume{
 		Name: "telegraf-config",
 		VolumeSource: corev1.VolumeSource{
@@ -139,12 +139,12 @@ func newVolume(name string) corev1.Volume {
 	}
 }
 
-func newContainer(pod *corev1.Pod, config *sidecarConfig) corev1.Container {
+func (h *sidecarHandler) newContainer(pod *corev1.Pod) corev1.Container {
 	var telegrafImage string
 	if customTelegrafImage, ok := pod.Annotations[TelegrafImage]; ok {
 		telegrafImage = customTelegrafImage
 	} else {
-		telegrafImage = config.TelegrafImage
+		telegrafImage = h.TelegrafImage
 	}
 	baseContainer := corev1.Container{
 		Name:  "telegraf",

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Test_skip(t *testing.T) {
+	handler := &sidecarHandler{}
 	withTelegraf := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -21,7 +22,7 @@ func Test_skip(t *testing.T) {
 			},
 		},
 	}
-	if skip(withTelegraf) {
+	if handler.skip(withTelegraf) {
 		t.Errorf("pod %v should not be skipped", withTelegraf.GetAnnotations())
 	}
 
@@ -32,7 +33,7 @@ func Test_skip(t *testing.T) {
 			},
 		},
 	}
-	if !skip(withoutTelegraf) {
+	if !handler.skip(withoutTelegraf) {
 		t.Errorf("pod %v should be skipped", withoutTelegraf.GetAnnotations())
 	}
 }
@@ -167,10 +168,10 @@ func Test_assembleConf(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			config := &sidecarConfig{
+			handler := &sidecarHandler{
 				EnableDefaultInternalPlugin: tt.enableDefaultInternalPlugin,
 			}
-			gotConfig, err := assembleConf(tt.pod, config, tt.classData)
+			gotConfig, err := handler.assembleConf(tt.pod, tt.classData)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("assembleConf() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -309,15 +310,15 @@ type: Opaque`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := &sidecarConfig{
+			handler := &sidecarHandler{
 				TelegrafImage:               defaultTelegrafImage,
 				EnableDefaultInternalPlugin: tt.enableDefaultInternalPlugin,
 			}
-			telegrafConf, err := assembleConf(tt.pod, config, "")
+			telegrafConf, err := handler.assembleConf(tt.pod, "")
 			if err != nil {
 				t.Errorf("unexpected error assembling sidecar configuration: %v", err)
 			}
-			secret, err := addSidecar(tt.pod, config, "myname", "mynamespace", telegrafConf)
+			secret, err := handler.addSidecar(tt.pod, "myname", "mynamespace", telegrafConf)
 			if err != nil {
 				t.Errorf("unexpected error adding to sidecar: %v", err)
 			}

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -39,12 +39,12 @@ func Test_skip(t *testing.T) {
 
 func Test_assembleConf(t *testing.T) {
 	tests := []struct {
-		name      string
-		pod       *corev1.Pod
-		classData string
-
-		wantConfig string
-		wantErr    bool
+		name                        string
+		pod                         *corev1.Pod
+		classData                   string
+		enableDefaultInternalPlugin bool
+		wantConfig                  string
+		wantErr                     bool
 	}{
 		{
 			name: "default prometheus settings",
@@ -151,10 +151,26 @@ func Test_assembleConf(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:                        "validate enable default internal plugin",
+			enableDefaultInternalPlugin: true,
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			wantConfig: `
+[[inputs.internal]]
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotConfig, err := assembleConf(tt.pod, tt.classData)
+
+			config := &sidecarConfig{
+				EnableDefaultInternalPlugin: tt.enableDefaultInternalPlugin,
+			}
+			gotConfig, err := assembleConf(tt.pod, config, tt.classData)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("assembleConf() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -168,10 +184,11 @@ func Test_assembleConf(t *testing.T) {
 
 func Test_addSidecar(t *testing.T) {
 	tests := []struct {
-		name       string
-		pod        *corev1.Pod
-		wantSecret string
-		wantPod    string
+		name                        string
+		pod                         *corev1.Pod
+		enableDefaultInternalPlugin bool
+		wantSecret                  string
+		wantPod                     string
 	}{
 		{
 			name: "validate prometheus inputs creation",
@@ -269,15 +286,38 @@ spec:
 status: {}
 			`,
 		},
+		{
+			name: "validate enable default internal plugin",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			enableDefaultInternalPlugin: true,
+			wantSecret: `apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: telegraf-config-myname
+  namespace: mynamespace
+stringData:
+  telegraf.conf: |2+
+
+    [[inputs.internal]]
+
+type: Opaque`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			telegrafConf, err := assembleConf(tt.pod, "")
+			config := &sidecarConfig{
+				TelegrafImage:               defaultTelegrafImage,
+				EnableDefaultInternalPlugin: tt.enableDefaultInternalPlugin,
+			}
+			telegrafConf, err := assembleConf(tt.pod, config, "")
 			if err != nil {
 				t.Errorf("unexpected error assembling sidecar configuration: %v", err)
 			}
-			secret, err := addSidecar(tt.pod, defaultTelegrafImage, "myname", "mynamespace", telegrafConf)
+			secret, err := addSidecar(tt.pod, config, "myname", "mynamespace", telegrafConf)
 			if err != nil {
 				t.Errorf("unexpected error adding to sidecar: %v", err)
 			}


### PR DESCRIPTION
Closes #10

Adds option and passes it to sidecar generation logic.

I've also made the `sidecarConfig` type to simplify adding more configuration specific to sidecar containers.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
