### PR TITLE
chore: improve README file with more detailed usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,19 @@
 [![CircleCI](https://circleci.com/gh/influxdata/telegraf-operator/tree/master.svg?style=svg)](https://circleci.com/gh/influxdata/telegraf-operator/tree/master)
 
 # The motto
-Easy things should be easy. Adding monitoring to your application has never been as easy as now. 
+Easy things should be easy. Adding monitoring to your application has never been as easy as now.
 
 Does your application exposes prometheus metrics? then adding `telegraf.influxdata.com/port: 8080` annotation to the pod is the only thing you need to add telegraf scraping to it
 
 # Why telegraf-operator?
 
-No one likes monitoring/observability, everybody wants to deploy applications but the burden of adding monitoring, fixing it, maintaining it should not weight that much. 
+No one likes monitoring/observability, everybody wants to deploy applications but the burden of adding monitoring, fixing it, maintaining it should not weight that much.
 
-# Installation
+# Getting started with telegraf-operator
 
-We don't provide yet a production-like deployment of `telegraf-operator` given the alpha status of the project 
+## Adding telegraf-operator in development mode
+
+We don't provide yet a production-like deployment of `telegraf-operator` given the alpha status of the project
 
 But we provide a development version that can be installed by running
 
@@ -22,9 +24,111 @@ But we provide a development version that can be installed by running
 kubectl apply -f https://github.com/influxdata/telegraf-operator/blob/master/deploy/dev.yml
 ```
 
-# Usage
+The command above deploys telegraf-operator, using a separate `telegraf-operator` namespace and registering webhooks that will inject a telegraf sidecar to all newly created pods.
 
-The available annotions are:
+In order to use `telegraf-operator`, what's also needed is to define where metrics should be sent.
+The [examples/classes.yml](examples/classes.yml) file provides a set of classes that can be used to get started.
+
+To create sample set of classes, simply run:
+
+```shell
+kubectl apply -f https://github.com/influxdata/telegraf-operator/blob/master/examples/classes.yml
+```
+
+## Installing InfluxDB for data retrieval
+
+In order to see the data, you can also deploy [InfluxDB](https://github.com/influxdata/influxdb/) v1 in your cluster, which also comes with [Chronograf](https://www.influxdata.com/time-series-platform/chronograf/), providing a web UI for InfluxDB v1.
+
+To set it up in your cluster, simply run:
+
+```shell
+kubectl apply -f https://github.com/influxdata/telegraf-operator/blob/master/deploy/influxdb.yml
+```
+
+After that, every new pod (created directly or by creating a deployment or statefulset) in your cluster will have include telegraf container for retrieving data.
+
+## Installing a sample application with telegraf-operator based monitoring set up
+
+You can try it by running one of our samples - such as a redis server. Simply do:
+
+```shell
+kubectl apply -f https://github.com/influxdata/telegraf-operator/blob/master/examples/redis.yml
+```
+
+You can verify the telegraf container is present by doing:
+
+```shell
+kubectl describe pod -n redis redis-0
+```
+
+The output should include a `telegraf` container.
+
+In order to see the results in InfluxDB and Chronograf, you will need to set up port-forwarding and then access Chronograf from your browser:
+
+```shell
+kubectl port-forward --namespace=influxdb svc/influxdb 8888:8888
+```
+
+Next, go to [http://localhost:8888](http://localhost:8888) and continue to [Explore](http://localhost:8888/sources/0/chronograf/data-explorer) section to see your data 
+
+# Configuration and usage
+
+Telegraf-operator consists of the following:
+
+* Global configuration - definition of where the metrics should be sent and other auxiliary configuration, specified as classes
+* Pod-level configuration - definition of how a pod can be monitored, such as ports for Prometheus scraping and additional configurations
+
+## Global configuration - classes
+
+Telegraf-operator is based on concepts of globally defined classes. Each class is a subset of Telegraf configuration and usually defines where Telegraf should be sending its outputs, along with other settings such as global tags.
+
+Usually classes are defined as a secret - such as in [classes.yml](examples/classes.yml) file - and each class maps to a key in a secret. For example:
+
+```
+stringData:
+  basic: |+
+    [[outputs.influxdb]]
+      urls = ["http://influxdb.influxdb:8086"]
+    [[outputs.file]]
+      files = ["stdout"]
+    [global_tags]
+      hostname = "$HOSTNAME"
+      nodename = "$NODENAME"
+      type = "app"
+```
+
+The above defines that any pod whose Telegraf class is `basic` will have its metrics sent to a specific URL, which in this case is an InfluxDB v1 instance deployed in same cluster. Its metrics will also be logged by `telegraf` container for convenience. The data will also have `hostname`, `nodename` and `type` tags added for all metrics.
+
+## Pod-level annotations
+
+Each pod (either standalone or as part of deployment as well as statefulset) may also specify how it should be monitored using metadata.
+
+The [redis.yml](examples/redis.yml) example adds annotation that enables the Redis plugin so that Telegraf will automatically retrieve metrics related to it.
+
+```
+apiVersion: apps/v1
+kind: StatefulSet
+  # ...
+spec:
+  template:
+    metadata:
+      annotations:
+        telegraf.influxdata.com/inputs: |+
+          [[inputs.redis]]
+            servers = ["tcp://localhost:6379"]
+        telegraf.influxdata.com/class: basic
+      # ...
+    spec:
+      containers:
+      - name: redis
+        image: redis:alpine
+```
+
+Please see [redis input plugin documentation](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redis) for more details on how the plugin can be configured.
+
+The `telegraf.influxdata.com/class` specifies that the `basic` class above should be used.
+
+The available pod annotions are:
 - `telegraf.influxdata.com/port`: is used to configure which port telegraf should scrape
 - `telegraf.influxdata.com/ports` : is used to configure which port telegraf should scrape, comma separated list of ports to scrape
 - `telegraf.influxdata.com/path` : is used to configure at which path to configure scraping to (a port must be configured also), will apply to all ports if multiple are configured
@@ -36,7 +140,12 @@ The available annotions are:
 - `telegraf.influxdata.com/class` : configures which kind of class to use (classes are configured on the operator)
 - `telegraf.influxdata.com/secret-env` : allows adding secrets to the telegraf sidecar in the form of environment variables
 
-### Maintainer
+# Contributing to telegraf-operator
+
+Please read the [CONTRIBUTING](CONTRIBUTING.md) file for more details on how to get started with contributing to to `telegraf-operator`.
+
+# Maintainers
 
 - [gitirabassi](https://github.com/gitirabassi)
 - [rawkode](https://github.com/rawkode)
+- [wojciechka](https://github.com/wojciechka/)

--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -84,8 +84,14 @@ spec:
       containers:
         - name: controller
           image: quay.io/influxdb/telegraf-operator:latest
+          # use IfNotPresent image pull policy to allow pushing / injecting
+          # container images to Kubernetes directly (such as when using kind)
           imagePullPolicy: IfNotPresent
           args:
+            # for development purposes, enable internal plugin to report
+            # telegraf metrics even if no other data is available
+            - --enable-default-internal-plugin=true
+            # default class to use if not specified by the pod
             - --telegraf-default-class=basic
             - --telegraf-classes-secret=telegraf-operator-classes
           env: 

--- a/deploy/influxdb.yml
+++ b/deploy/influxdb.yml
@@ -19,8 +19,11 @@ spec:
         app: influxdb
     spec:
       containers:
-      - name: influxdb
-        image: influxdb:1.7.9
+        - name: influxdb
+          image: influxdb:1.7.9
+        - name: chronograf
+          image: chronograf:1.6.2
+          args: ["--influxdb-url=http://localhost:8086"]
 ---
 apiVersion: v1
 kind: Service
@@ -31,7 +34,9 @@ metadata:
   namespace: influxdb
 spec:
   ports:
-  - name: server
-    port: 8086
+    - name: server
+      port: 8086
+    - name: chronograf
+      port: 8888
   selector:
     app: influxdb

--- a/examples/classes.yml
+++ b/examples/classes.yml
@@ -1,37 +1,16 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: telegraf-operator
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: telegraf-operator-classes
   namespace: telegraf-operator
 stringData:
-  acc: |+
-    [[outputs.influxdb_v2]]
-      urls = ["zzzzzzz"]
-      token = "zzzzzz"
-      organization = "xxxx"
-      bucket = "infra"
-      timeout = "5s"
-    [global_tags]
-      env = "acc"
-      hostname = "$HOSTNAME"
-      nodename = "$NODENAME"
-    [agent]      interval = "10s"
-      round_interval = true
-      metric_batch_size = 100000
-      metric_buffer_limit = 100000
-      collection_jitter = "0s"
-  influxdb_v2: |+
-    [[outputs.influxdb_v2]]
-      urls = ["xxxxxx"]
-      token = "xxxxxxx"
-      organization = "xxxxxxx"
-      bucket = "app"
-      timeout = "5s"
-      metric_batch_size = 10000
-      metric_buffer_limit = 100000
-    [global_tags]
-      hostname = "$HOSTNAME"
-      nodename = "$NODENAME"
+  # basic classes that can be used to develop telegraf-operator ; these classes
+  # report to InfluxDB v1 in same cluster as well as to stdout for convenience
   app: |+
     [[outputs.influxdb]]
       urls = ["http://influxdb.influxdb:8086"]
@@ -58,3 +37,33 @@ stringData:
       hostname = "$HOSTNAME"
       nodename = "$NODENAME"
       type = "infra"
+  # example of reporting to InfluxDB v2
+  influxdb_v2: |+
+    [[outputs.influxdb_v2]]
+      urls = ["xxxxxx"]
+      token = "xxxxxxx"
+      organization = "xxxxxxx"
+      bucket = "app"
+      timeout = "5s"
+      metric_batch_size = 10000
+      metric_buffer_limit = 100000
+    [global_tags]
+      hostname = "$HOSTNAME"
+      nodename = "$NODENAME"
+  # example for a specific environment that sets global tags and reports to InfluxDB V2
+  acc: |+
+    [[outputs.influxdb_v2]]
+      urls = ["zzzzzzz"]
+      token = "zzzzzz"
+      organization = "xxxx"
+      bucket = "infra"
+      timeout = "5s"
+    [global_tags]
+      env = "acc"
+      hostname = "$HOSTNAME"
+      nodename = "$NODENAME"
+    [agent]      interval = "10s"
+      round_interval = true
+      metric_batch_size = 100000
+      metric_buffer_limit = 100000
+      collection_jitter = "0s"


### PR DESCRIPTION
Closes #21

Improve README file with more detailed instructions for setting up `telegraf-operator`.

This also adds Chronograf to the InfluxDB deployment to simplify visualisation of the data.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
