### PR TITLE
feat: allow configuring custom resources for telegraf sidecar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,8 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go .
-COPY sidecar.go .
-COPY handler.go .
-COPY class_data.go .
+COPY main.go sidecar.go handler.go class_data.go ./
+
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager *.go
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ The available pod annotions are:
 - `telegraf.influxdata.com/image` : is used to configure telegraf image to be used for the `telegraf` sidecar container
 - `telegraf.influxdata.com/class` : configures which kind of class to use (classes are configured on the operator)
 - `telegraf.influxdata.com/secret-env` : allows adding secrets to the telegraf sidecar in the form of environment variables
+- `telegraf.influxdata.com/requests-cpu` : allows specifying resource requests for CPU
+- `telegraf.influxdata.com/requests-memory` : allows specifying resource requests for memory
+- `telegraf.influxdata.com/limits-cpu` : allows specifying resource limits for CPU
+- `telegraf.influxdata.com/limits-memory` : allows specifying resource limits for memory
+
 
 # Contributing to telegraf-operator
 

--- a/examples/redis.yml
+++ b/examples/redis.yml
@@ -17,6 +17,9 @@ spec:
           [[inputs.redis]]
             servers = ["tcp://localhost:6379"]
         telegraf.influxdata.com/class: app
+        telegraf.influxdata.com/limits-cpu: '750m'
+        # invalid memory limit, which will be ignored
+        telegraf.influxdata.com/limits-memory: '800x'
     spec:
       containers:
       - name: redis


### PR DESCRIPTION
Closes #27

Add configuration options along with validation for default resource requests and limits as well as an option to override those at individual pod level.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
