### PR TITLE
feat: improve secret management to handle existing secrets ; add annotation

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,12 +65,15 @@ func main() {
 	var enableIstioInjection bool
 	var istioOutputClass string
 	var istioTelegrafImage string
+	var requireAnnotationsForSecret bool
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableDefaultInternalPlugin, "enable-default-internal-plugin", false,
 		"Enable internal plugin in telegraf for all sidecar. If disabled, can be set explicitly via appropriate annotation")
+	flag.BoolVar(&requireAnnotationsForSecret, "require-annotations-for-secret", false,
+		"Require the annotations to be present when updating a secret")
 	flag.StringVar(&telegrafClassesDirectory, "telegraf-classes-directory", "/config/classes", "The name of the directory in which the telegraf classes are configured")
 	flag.StringVar(&defaultTelegrafClass, "telegraf-default-class", "default", "Default telegraf class to use")
 	flag.StringVar(&telegrafImage, "telegraf-image", defaultTelegrafImage, "Telegraf image to inject")
@@ -143,9 +146,10 @@ func main() {
 	}
 
 	hookServer.Register("/mutate-v1-pod", &webhook.Admission{Handler: &podInjector{
-		Logger:           logger,
-		SidecarHandler:   sidecar,
-		ClassDataHandler: classData,
+		Logger:                      logger,
+		SidecarHandler:              sidecar,
+		ClassDataHandler:            classData,
+		RequireAnnotationsForSecret: requireAnnotationsForSecret,
 	}})
 
 	setupLog.Info("starting manager")

--- a/sidecar.go
+++ b/sidecar.go
@@ -56,6 +56,10 @@ const (
 	// TelegrafLimitsMemory allows specifying custom memory resource limits
 	TelegrafLimitsMemory = "telegraf.influxdata.com/limits-memory"
 	telegrafSecretInfix  = "config"
+
+	TelegrafSecretAnnotationKey   = "app.kubernetes.io/managed-by"
+	TelegrafSecretAnnotationValue = "telegraf-operator"
+	TelegrafSecretDataKey         = "telegraf.conf"
 )
 
 type sidecarHandler struct {
@@ -268,10 +272,13 @@ func (h *sidecarHandler) newSecret(pod *corev1.Pod, name, namespace, containerNa
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s-%s", containerName, telegrafSecretInfix, name),
 			Namespace: namespace,
+			Annotations: map[string]string{
+				TelegrafSecretAnnotationKey: TelegrafSecretAnnotationValue,
+			},
 		},
 		Type: "Opaque",
 		StringData: map[string]string{
-			"telegraf.conf": telegrafConf,
+			TelegrafSecretDataKey: telegrafConf,
 		},
 	}, nil
 }

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -19,6 +19,8 @@ var (
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
   name: telegraf-config-myname
   namespace: mynamespace
@@ -30,6 +32,8 @@ type: Opaque`
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
   name: telegraf-istio-config-myname
   namespace: mynamespace
@@ -293,6 +297,8 @@ func Test_addSidecars(t *testing.T) {
 				`apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
   name: telegraf-config-myname
   namespace: mynamespace
@@ -398,6 +404,8 @@ status: {}
 				`apiVersion: v1
 kind: Secret
 metadata:
+  annotations:
+    app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
   name: telegraf-config-myname
   namespace: mynamespace


### PR DESCRIPTION
Closes #40 

Improves support for handling secrets for telegraf sidecar.

Adds checks to avoid accidental overwrite of secrets.

Adds an annotation to allow easier detection of secrets managed by `telegraf-operator` and flag to optionally only overwrite secrets with said annotation.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
