### PR TITLE
fix(circleci): update circleci go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /.*/
+      - build
       - deploy:
           requires:
             - build
@@ -27,7 +24,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13 # We shell out to git in tests, and circleci/golang should have it installed.
+      - image: circleci/golang:1.16 # We shell out to git in tests, and circleci/golang should have it installed.
 
     working_directory: ~/telegraf-operator # Doesn't need to be in GOPATH since it's a Go module.
 


### PR DESCRIPTION
Upgrading the CircleCI go version used

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [x] Rebased/mergeable
