### PR TITLE
feat: add telegraf.influxdata.com/class label to secrets managed by telegraf

### DIFF
--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -22,6 +22,8 @@ metadata:
   annotations:
     app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
+  labels:
+    telegraf.influxdata.com/class: default
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -35,6 +37,8 @@ metadata:
   annotations:
     app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
+  labels:
+    telegraf.influxdata.com/class: istio
   name: telegraf-istio-config-myname
   namespace: mynamespace
 stringData:
@@ -300,6 +304,8 @@ metadata:
   annotations:
     app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
+  labels:
+    telegraf.influxdata.com/class: default
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -406,6 +412,8 @@ metadata:
   annotations:
     app.kubernetes.io/managed-by: telegraf-operator
   creationTimestamp: null
+  labels:
+    telegraf.influxdata.com/class: default
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:


### PR DESCRIPTION
Adds a label that specifies class that was used when creating and/or updating secrets required for pods.

This will make it easier to secrets managed by telegraf-operator and update them.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
