### PR TITLE
feat: allow passing --watch-config flag to telegraf

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -216,7 +216,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -271,7 +271,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -320,7 +320,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -377,7 +377,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -443,7 +443,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.11","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -492,7 +492,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -543,7 +543,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -636,7 +636,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -693,8 +693,8 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
-					`{"op":"add","path":"/spec/containers/2","value":{"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}},{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 	var telegrafClassesDirectory string
 	var defaultTelegrafClass string
 	var telegrafImage string
+	var telegrafWatchConfig string
 	var enableDefaultInternalPlugin bool
 	var telegrafRequestsCPU string
 	var telegrafRequestsMemory string
@@ -65,6 +66,7 @@ func main() {
 	var enableIstioInjection bool
 	var istioOutputClass string
 	var istioTelegrafImage string
+	var istioTelegrafWatchConfig string
 	var requireAnnotationsForSecret bool
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -77,6 +79,7 @@ func main() {
 	flag.StringVar(&telegrafClassesDirectory, "telegraf-classes-directory", "/config/classes", "The name of the directory in which the telegraf classes are configured")
 	flag.StringVar(&defaultTelegrafClass, "telegraf-default-class", "default", "Default telegraf class to use")
 	flag.StringVar(&telegrafImage, "telegraf-image", defaultTelegrafImage, "Telegraf image to inject")
+	flag.StringVar(&telegrafWatchConfig, "telegraf-watch-config", "", "Optional setting to use for telegraf to watch for changes in configuration")
 	flag.StringVar(&telegrafRequestsCPU, "telegraf-requests-cpu", defaultRequestsCPU, "Default requests for CPU")
 	flag.StringVar(&telegrafRequestsMemory, "telegraf-requests-memory", defaultRequestsMemory, "Default requests for memory")
 	flag.StringVar(&telegrafLimitsCPU, "telegraf-limits-cpu", defaultLimitsCPU, "Default limits for CPU")
@@ -85,6 +88,7 @@ func main() {
 		"Enable injecting additional sidecar for monitoring istio sidecar container. If enabled, additional sidecar telegraf-istio will be added for pods with the Istio annotation enabled")
 	flag.StringVar(&istioOutputClass, "istio-output-class", "istio", "Class to use for adding telegraf-istio sidecar to monitor its sidecar")
 	flag.StringVar(&istioTelegrafImage, "istio-telegraf-image", "", "If specified, use a custom image for telegraf-istio sidecar")
+	flag.StringVar(&istioTelegrafWatchConfig, "istio-telegraf-watch-config", "", "Optional setting to use for telegraf to watch for changes in configuration")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -129,10 +133,12 @@ func main() {
 		Logger:                      logger,
 		TelegrafDefaultClass:        defaultTelegrafClass,
 		TelegrafImage:               telegrafImage,
+		TelegrafWatchConfig:         telegrafWatchConfig,
 		EnableDefaultInternalPlugin: enableDefaultInternalPlugin,
 		EnableIstioInjection:        enableIstioInjection,
 		IstioOutputClass:            istioOutputClass,
 		IstioTelegrafImage:          istioTelegrafImage,
+		IstioTelegrafWatchConfig:    istioTelegrafWatchConfig,
 		RequestsCPU:                 telegrafRequestsCPU,
 		RequestsMemory:              telegrafRequestsMemory,
 		LimitsCPU:                   telegrafLimitsCPU,

--- a/sidecar.go
+++ b/sidecar.go
@@ -68,6 +68,7 @@ type sidecarHandler struct {
 	Logger                      logr.Logger
 	TelegrafDefaultClass        string
 	TelegrafImage               string
+	TelegrafWatchConfig         string
 	EnableDefaultInternalPlugin bool
 	RequestsCPU                 string
 	RequestsMemory              string
@@ -76,6 +77,7 @@ type sidecarHandler struct {
 	EnableIstioInjection        bool
 	IstioOutputClass            string
 	IstioTelegrafImage          string
+	IstioTelegrafWatchConfig    string
 }
 
 type sidecarHandlerResponse struct {
@@ -361,9 +363,12 @@ func (h *sidecarHandler) newContainer(pod *corev1.Pod, containerName string) (co
 		return corev1.Container{}, err
 	}
 
+	telegrafContainerCommand := createTelegrafCommand(h.TelegrafWatchConfig)
+
 	baseContainer := corev1.Container{
-		Name:  containerName,
-		Image: telegrafImage,
+		Name:    containerName,
+		Image:   telegrafImage,
+		Command: telegrafContainerCommand,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				"cpu":    parsedLimitsCPU,
@@ -434,9 +439,12 @@ func (h *sidecarHandler) newIstioContainer(pod *corev1.Pod, containerName string
 		telegrafImage = h.TelegrafImage
 	}
 
+	telegrafContainerCommand := createTelegrafCommand(h.IstioTelegrafWatchConfig)
+
 	baseContainer := corev1.Container{
-		Name:  containerName,
-		Image: telegrafImage,
+		Name:    containerName,
+		Image:   telegrafImage,
+		Command: telegrafContainerCommand,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				"cpu":    parsedLimitsCPU,
@@ -499,4 +507,12 @@ func podHasContainerName(pod *corev1.Pod, name string) bool {
 		}
 	}
 	return false
+}
+
+func createTelegrafCommand(watchConfig string) []string {
+	command := []string{"telegraf", "--config", "/etc/telegraf/telegraf.conf"}
+	if watchConfig != "" {
+		command = append(command, "--watch-config", watchConfig)
+	}
+	return command
 }


### PR DESCRIPTION
Allows `telegraf` to be reloading configuration on changes so that at some point the secret for each pod can be regenerated.

Depends on influxdata/telegraf#9485 being merged and released for the `--telegraf-watch-config` option to be useful.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
