### PR TITLE
chore: add pod-name label to all secrets to simplify updates of secrets

### DIFF
--- a/sidecar.go
+++ b/sidecar.go
@@ -61,6 +61,7 @@ const (
 	TelegrafSecretAnnotationValue = "telegraf-operator"
 	TelegrafSecretDataKey         = "telegraf.conf"
 	TelegrafSecretLabelClassName  = TelegrafClass
+	TelegrafSecretLabelPodName    = "telegraf.influxdata.com/pod-name"
 )
 
 type sidecarHandler struct {
@@ -278,6 +279,7 @@ func (h *sidecarHandler) newSecret(pod *corev1.Pod, className, name, namespace, 
 			},
 			Labels: map[string]string{
 				TelegrafSecretLabelClassName: className,
+				TelegrafSecretLabelPodName:   name,
 			},
 		},
 		Type: "Opaque",

--- a/sidecar.go
+++ b/sidecar.go
@@ -61,7 +61,7 @@ const (
 	TelegrafSecretAnnotationValue = "telegraf-operator"
 	TelegrafSecretDataKey         = "telegraf.conf"
 	TelegrafSecretLabelClassName  = TelegrafClass
-	TelegrafSecretLabelPodName    = "telegraf.influxdata.com/pod-name"
+	TelegrafSecretLabelPod        = "telegraf.influxdata.com/pod"
 )
 
 type sidecarHandler struct {
@@ -279,7 +279,7 @@ func (h *sidecarHandler) newSecret(pod *corev1.Pod, className, name, namespace, 
 			},
 			Labels: map[string]string{
 				TelegrafSecretLabelClassName: className,
-				TelegrafSecretLabelPodName:   name,
+				TelegrafSecretLabelPod:       name,
 			},
 		},
 		Type: "Opaque",

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -24,7 +24,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
-    telegraf.influxdata.com/pod-name: myname
+    telegraf.influxdata.com/pod: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -40,7 +40,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: istio
-    telegraf.influxdata.com/pod-name: myname
+    telegraf.influxdata.com/pod: myname
   name: telegraf-istio-config-myname
   namespace: mynamespace
 stringData:
@@ -308,7 +308,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
-    telegraf.influxdata.com/pod-name: myname
+    telegraf.influxdata.com/pod: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -417,7 +417,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
-    telegraf.influxdata.com/pod-name: myname
+    telegraf.influxdata.com/pod: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -24,6 +24,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
+    telegraf.influxdata.com/pod-name: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -39,6 +40,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: istio
+    telegraf.influxdata.com/pod-name: myname
   name: telegraf-istio-config-myname
   namespace: mynamespace
 stringData:
@@ -306,6 +308,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
+    telegraf.influxdata.com/pod-name: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
@@ -414,6 +417,7 @@ metadata:
   creationTimestamp: null
   labels:
     telegraf.influxdata.com/class: default
+    telegraf.influxdata.com/pod-name: myname
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:


### PR DESCRIPTION
After investigating more about secret re-creation I realized that it may be easier to set the label on the secret rather than guess the pod name from the secret name.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
