### PR TITLE
chore: enable hot-reload in dev.yml ; update default version of telegraf to allow it

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -106,9 +106,9 @@ spec:
             # allow injecting telegraf-istio sidecar for pods with
             # istio sidecar annotations enabled
             - --enable-istio-injection=true
-            # if telegraf image supports it, telegraf-watch-config can be set so
-            #  telegraf-opeator and telegraf hot reload changes when classes change
-            # - --telegraf-watch-config=inotify
+            # if telegraf image supports it (as of version 1.19.2), telegraf-watch-config can be
+            # set to enable telegraf-opeator and telegraf hot reloading changes to classes secret
+            - --telegraf-watch-config=inotify
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/handler_test.go
+++ b/handler_test.go
@@ -216,7 +216,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -377,7 +377,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -492,7 +492,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -543,7 +543,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -636,7 +636,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -693,8 +693,8 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
-					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.14","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}},{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 const (
-	defaultTelegrafImage  = "docker.io/library/telegraf:1.14"
+	defaultTelegrafImage  = "docker.io/library/telegraf:1.19"
 	defaultRequestsCPU    = "10m"
 	defaultRequestsMemory = "10Mi"
 	defaultLimitsCPU      = "200m"

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -365,7 +365,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:
@@ -491,7 +491,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:
@@ -538,7 +538,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:
@@ -585,7 +585,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:
@@ -683,7 +683,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf-istio
     resources:
       limits:
@@ -813,7 +813,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:
@@ -834,7 +834,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf-istio
     resources:
       limits:
@@ -887,7 +887,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.14
+    image: docker.io/library/telegraf:1.19
     name: telegraf
     resources:
       limits:


### PR DESCRIPTION
Enables telegraf hot reload in dev mode.

Also changes default image to latest 1.19 as it's needed for hot reloading to work.
