### PR TITLE
fix: add latest tag when releasing a new version of telegraf-operator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,4 +122,5 @@ jobs:
               --output=type=registry \
               --platform linux/amd64,linux/arm64,linux/arm/v7 \
               --tag "$IMAGE:$CIRCLE_TAG" \
+              --tag "$IMAGE:latest" \
               --file Dockerfile.multi-arch .


### PR DESCRIPTION
Helps with #48

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
