### PR TITLE
chore(Makefile): improve waiting for telegraf-operator be ready in kind-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,7 @@ kind-test:
 	kubectl config use-context kind-telegraf-operator-test
 	kubectl apply -f examples/classes.yml
 	kubectl apply -f deploy/dev.yml
-	# wait 20 seconds to ensure the pod is already in running state
-	sleep 20
+	kubectl wait --timeout=5m -n telegraf-operator --for=condition=available deployment/telegraf-operator
 	kubectl apply -f examples/redis.yml
 	sleep 2
 	kubectl describe pod --namespace=test redis


### PR DESCRIPTION
Small change as the previous sleep was arbitrary and a wait based approach is more reliable.
