### PR TITLE
Add labels "telegraf.influxdata.com/shared-volume", "telegraf.influxdata.com/shared-volume-path"

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,6 +69,9 @@ func main() {
 	var istioTelegrafWatchConfig string
 	var requireAnnotationsForSecret bool
 
+	var telegrafSharedVolume string
+	var telegrafSharedVolumePath string
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
@@ -89,6 +92,10 @@ func main() {
 	flag.StringVar(&istioOutputClass, "istio-output-class", "istio", "Class to use for adding telegraf-istio sidecar to monitor its sidecar")
 	flag.StringVar(&istioTelegrafImage, "istio-telegraf-image", "", "If specified, use a custom image for telegraf-istio sidecar")
 	flag.StringVar(&istioTelegrafWatchConfig, "istio-telegraf-watch-config", "", "Optional setting to use for telegraf to watch for changes in configuration")
+
+	flag.StringVar(&telegrafSharedVolume, "telegraf-shared-volume", "", "Enable shared volume emptyDir")
+	flag.StringVar(&telegrafSharedVolumePath, "telegraf-shared-volume-path", "", "Enable shared volume mount path")
+
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
@@ -140,6 +147,8 @@ func main() {
 		RequestsMemory:              telegrafRequestsMemory,
 		LimitsCPU:                   telegrafLimitsCPU,
 		LimitsMemory:                telegrafLimitsMemory,
+		SharedVolumeName:            telegrafSharedVolume,
+		SharedVolumePath:            telegrafSharedVolumePath,
 	}
 
 	err = sidecar.validateRequestsAndLimits()

--- a/sidecar.go
+++ b/sidecar.go
@@ -367,11 +367,11 @@ func (h *sidecarHandler) newContainer(pod *corev1.Pod, containerName string) (co
 	}
 
 	// For shared volume
-	if customSharedVolume, ok := pod.Annotations[telegrafSharedVolume]; ok {
+	if customSharedVolume, ok := pod.Annotations[TelegrafSharedVolume]; ok {
 		telegrafSharedVolume = customSharedVolume
 	}
 
-	if customSharedVolumePath, ok := pod.Annotations[telegrafSharedVolumePath]; ok {
+	if customSharedVolumePath, ok := pod.Annotations[TelegrafSharedVolumePath]; ok {
 		telegrafSharedVolumePath = customSharedVolumePath
 	}
 
@@ -538,11 +538,11 @@ func (h *sidecarHandler) newIstioContainer(pod *corev1.Pod, containerName string
 	var telegrafSharedVolumePath string
 	var err error
 
-	if customSharedVolume, ok := pod.Annotations[telegrafSharedVolume]; ok {
+	if customSharedVolume, ok := pod.Annotations[TelegrafSharedVolume]; ok {
 		telegrafSharedVolume = customSharedVolume
 	}
 
-	if customSharedVolumePath, ok := pod.Annotations[telegrafSharedVolumePath]; ok {
+	if customSharedVolumePath, ok := pod.Annotations[TelegrafSharedVolumePath]; ok {
 		telegrafSharedVolumePath = customSharedVolumePath
 	}
 

--- a/sidecar.go
+++ b/sidecar.go
@@ -92,6 +92,8 @@ type sidecarHandler struct {
 	IstioOutputClass            string
 	IstioTelegrafImage          string
 	IstioTelegrafWatchConfig    string
+	SharedVolumeName            string
+	SharedVolumePath            string
 }
 
 type sidecarHandlerResponse struct {


### PR DESCRIPTION
Adds these labels for a sidecar container mounts the shared volume. 
I used telegraf-operator to monitor varnish by varnishstat. The varnishstat needs to read data in the directory /var/lib/varnish/. So these labels allow the main container and sidecar shared common volumes.

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
