### PR TITLE
feat: allow disabling telegraf resources by providing an empty string

### DIFF
--- a/sidecar.go
+++ b/sidecar.go
@@ -134,18 +134,14 @@ func (h *sidecarHandler) shouldAddIstioTelegrafSidecar(pod *corev1.Pod) bool {
 	return false
 }
 
-func (h *sidecarHandler) validateRequestsAndLimits() error {
-	if _, err := resource.ParseQuantity(h.RequestsCPU); err != nil {
-		return err
-	}
-	if _, err := resource.ParseQuantity(h.RequestsMemory); err != nil {
-		return err
-	}
-	if _, err := resource.ParseQuantity(h.LimitsCPU); err != nil {
-		return err
-	}
-	if _, err := resource.ParseQuantity(h.LimitsMemory); err != nil {
-		return err
+func (h *sidecarHandler) validateRequestsAndLimits() (err error) {
+	for _, value := range []string{h.RequestsCPU, h.RequestsMemory, h.LimitsCPU, h.LimitsMemory} {
+		if value != "" {
+			_, err = resource.ParseQuantity(value)
+			if err != nil {
+				return
+			}
+		}
 	}
 
 	return nil
@@ -354,6 +350,10 @@ func (h *sidecarHandler) parseCustomOrDefaultQuantity(result corev1.ResourceList
 	var quantity resource.Quantity
 	if quantity, err = resource.ParseQuantity(customQuantity); err != nil {
 		h.Logger.Info(fmt.Sprintf("unable to parse resource \"%s\": %v", customQuantity, err))
+
+		if defaultQuantity == "" {
+			return nil
+		}
 		quantity, err = resource.ParseQuantity(defaultQuantity)
 	}
 

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -132,6 +132,16 @@ func Test_validateRequestsAndLimits(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "validate empty values are accepted",
+			sidecar: &sidecarHandler{
+				RequestsCPU:    "",
+				RequestsMemory: "",
+				LimitsCPU:      "",
+				LimitsMemory:   "",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -1192,6 +1192,53 @@ status: {}
       `,
 			wantSecrets: []string{testEmptySecret},
 		},
+		{
+			name: "validate empty resource requests",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						TelegrafClass:          "default",
+						TelegrafRequestsCPU:    "",
+						TelegrafRequestsMemory: "",
+						TelegrafLimitsCPU:      "",
+						TelegrafLimitsMemory:   "",
+					},
+				},
+			},
+			wantPod: `
+metadata:
+  annotations:
+    telegraf.influxdata.com/class: default
+    telegraf.influxdata.com/limits-cpu: ""
+    telegraf.influxdata.com/limits-memory: ""
+    telegraf.influxdata.com/requests-cpu: ""
+    telegraf.influxdata.com/requests-memory: ""
+  creationTimestamp: null
+spec:
+  containers:
+  - command:
+    - telegraf
+    - --config
+    - /etc/telegraf/telegraf.conf
+    env:
+    - name: NODENAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    image: docker.io/library/telegraf:1.19
+    name: telegraf
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/telegraf
+      name: telegraf-config
+  volumes:
+  - name: telegraf-config
+    secret:
+      secretName: telegraf-config-myname
+status: {}
+      `,
+			wantSecrets: []string{testEmptySecret},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #84

Allows disabling resource requests and/or limits for telegraf sidecars by providing an empty string as value.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
