### PR TITLE
Add capability to specify Prometheus metrics version

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Users can configure the `inputs.prometheus` plugin by setting the following anno
 - `telegraf.influxdata.com/path` : is used to configure at which path to configure scraping to (a port must be configured also), will apply to all ports if multiple are configured
 - `telegraf.influxdata.com/scheme` : is used to configure at the scheme for the metrics to scrape, will apply to all ports if multiple are configured ( only `http` or `https` are allowed as values)
 - `telegraf.influxdata.com/interval` : is used to configure interval for telegraf scraping (Go style duration, e.g 5s, 30s, 2m .. )
+- `telegraf.influxdata.com/version` : is used to configure which metrics parsing version to use (1, 2)
 
 ### Example Prometheus Scraping
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Users can configure the `inputs.prometheus` plugin by setting the following anno
 - `telegraf.influxdata.com/path` : is used to configure at which path to configure scraping to (a port must be configured also), will apply to all ports if multiple are configured
 - `telegraf.influxdata.com/scheme` : is used to configure at the scheme for the metrics to scrape, will apply to all ports if multiple are configured ( only `http` or `https` are allowed as values)
 - `telegraf.influxdata.com/interval` : is used to configure interval for telegraf scraping (Go style duration, e.g 5s, 30s, 2m .. )
-- `telegraf.influxdata.com/version` : is used to configure which metrics parsing version to use (1, 2)
+- `telegraf.influxdata.com/metric-version` : is used to configure which metrics parsing version to use (1, 2)
 
 ### Example Prometheus Scraping
 
@@ -171,6 +171,7 @@ spec:
         telegraf.influxdata.com/path: /metrics
         telegraf.influxdata.com/port: "8086"
         telegraf.influxdata.com/scheme: http
+        telegraf.influxdata.com/metric-version: 2
       # ...
     spec:
       containers:
@@ -184,6 +185,7 @@ spec:
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:8086/metrics"]
   interval = "30s"
+  metric_version = 2
 
 [[inputs.internal]]
 ```

--- a/sidecar.go
+++ b/sidecar.go
@@ -35,8 +35,8 @@ const (
 	TelegrafMetricsPath = "telegraf.influxdata.com/path"
 	// TelegrafMetricsScheme is used to configure at the scheme for the metrics to scrape, will apply to all ports if multiple are configured
 	TelegrafMetricsScheme = "telegraf.influxdata.com/scheme"
-	// TelegrafMetricsVersion is used to configure which metrics parsing version to use (1, 2)
-	TelegrafMetricsVersion = "telegraf.influxdata.com/version"
+	// TelegrafMetricVersion is used to configure which metrics parsing version to use (1, 2)
+	TelegrafMetricVersion = "telegraf.influxdata.com/metric-version"
 	// TelegrafInterval is used to configure interval for telegraf (Go style duration, e.g 5s, 30s, 2m .. )
 	TelegrafInterval = "telegraf.influxdata.com/interval"
 	// TelegrafRawInput is used to configure custom inputs for telegraf
@@ -248,7 +248,7 @@ func (h *sidecarHandler) assembleConf(pod *corev1.Pod, className string) (telegr
 			intervalConfig = fmt.Sprintf("interval = \"%s\"", intervalRaw)
 		}
 		versionConfig := ""
-		if versionRaw, ok := pod.Annotations[TelegrafMetricsVersion]; ok {
+		if versionRaw, ok := pod.Annotations[TelegrafMetricVersion]; ok {
 			versionConfig = fmt.Sprintf("metric_version = %s", versionRaw)
 		}
 		urls := []string{}

--- a/sidecar.go
+++ b/sidecar.go
@@ -247,10 +247,17 @@ func (h *sidecarHandler) assembleConf(pod *corev1.Pod, className string) (telegr
 		if ok {
 			intervalConfig = fmt.Sprintf("interval = \"%s\"", intervalRaw)
 		}
+
 		versionConfig := ""
 		if versionRaw, ok := pod.Annotations[TelegrafMetricVersion]; ok {
-			versionConfig = fmt.Sprintf("metric_version = %s", versionRaw)
+			version, err := strconv.ParseInt(versionRaw, 10, 0)
+			if err != nil {
+				return "", fmt.Errorf("value supplied for %s must be a number, %s given", TelegrafMetricVersion, versionRaw)
+			}
+
+			versionConfig = fmt.Sprintf("metric_version = %d", version)
 		}
+
 		urls := []string{}
 		for _, port := range ports {
 			urls = append(urls, fmt.Sprintf("%s://127.0.0.1:%s%s", scheme, port, path))

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -233,7 +233,7 @@ func Test_assembleConf(t *testing.T) {
 						TelegrafInterval:       "10s",
 						TelegrafMetricsPorts:   "6060,8086",
 						TelegrafEnableInternal: "true",
-						TelegrafMetricsVersion: "2",
+						TelegrafMetricVersion:  "2",
 					},
 				},
 			},
@@ -252,8 +252,8 @@ func Test_assembleConf(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						TelegrafMetricsPorts:   "6060",
-						TelegrafMetricsVersion: "2",
+						TelegrafMetricsPorts:  "6060",
+						TelegrafMetricVersion: "2",
 					},
 				},
 			},

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -266,6 +266,18 @@ func Test_assembleConf(t *testing.T) {
 `,
 		},
 		{
+			name: "invalid metric_version value",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						TelegrafMetricsPorts:  "6060",
+						TelegrafMetricVersion: "invalid",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "valid TOML syntax",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -181,6 +181,7 @@ func Test_assembleConf(t *testing.T) {
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:6060/metrics"]
   
+  
 
 `,
 		},
@@ -196,6 +197,7 @@ func Test_assembleConf(t *testing.T) {
 			wantConfig: `
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:6060/metrics", "http://127.0.0.1:8086/metrics"]
+  
   
 
 `,
@@ -215,6 +217,7 @@ func Test_assembleConf(t *testing.T) {
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:6060/metrics"]
   
+  
 
 [global_tags]
   dc = "us-east-1"
@@ -230,6 +233,7 @@ func Test_assembleConf(t *testing.T) {
 						TelegrafInterval:       "10s",
 						TelegrafMetricsPorts:   "6060,8086",
 						TelegrafEnableInternal: "true",
+						TelegrafMetricsVersion: "2",
 					},
 				},
 			},
@@ -237,8 +241,27 @@ func Test_assembleConf(t *testing.T) {
 [[inputs.prometheus]]
   urls = ["https://127.0.0.1:6060/metrics/usage", "https://127.0.0.1:8086/metrics/usage"]
   interval = "10s"
+  metric_version = 2
 
 [[inputs.internal]]
+
+`,
+		},
+		{
+			name: "default prometheus settings with version, no interval",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						TelegrafMetricsPorts:   "6060",
+						TelegrafMetricsVersion: "2",
+					},
+				},
+			},
+			wantConfig: `
+[[inputs.prometheus]]
+  urls = ["http://127.0.0.1:6060/metrics"]
+  
+  metric_version = 2
 
 `,
 		},
@@ -386,7 +409,7 @@ metadata:
   name: telegraf-config-myname
   namespace: mynamespace
 stringData:
-  telegraf.conf: "\n[[inputs.prometheus]]\n  urls = [\"http://127.0.0.1:6060/metrics\"]\n  \n\n"
+  telegraf.conf: "\n[[inputs.prometheus]]\n  urls = [\"http://127.0.0.1:6060/metrics\"]\n  \n  \n\n"
 type: Opaque`,
 			},
 		},


### PR DESCRIPTION
Closes #88 

This PR adds the following annotation: `telegraf.influxdata.com/metric-version`

When this annotation is present on a resource, the generated Prometheus input config will include the `metric_version` key:
```
[[inputs.prometheus]]
  urls = ["http://127.0.0.1:6060/metrics"]
  
  metric_version = 2
```

While there are only 2 possible values (1, 2), there was no validation present on other annotation values, so I did not include that here either. The blank line comes from not specifying the interval annotation. While it doesn't look the best, it is valid toml. If desired, I can refactor to remove the empty line.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [ ] Tests pass (no build errors)
- [ ] Rebased/mergeable
