### PR TITLE
chore: update permissions in community-operators template

### DIFF
--- a/_templates/community-operator/release/manifests-clusterserviceversion.ejs.t
+++ b/_templates/community-operator/release/manifests-clusterserviceversion.ejs.t
@@ -63,6 +63,19 @@ spec:
             - secrets
             verbs:
             - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            verbs:
+            - get
           serviceAccountName: telegraf-operator
       deployments:
         - name: telegraf-operator


### PR DESCRIPTION
Add permissions that are required if telegraf-operator is running with hot reloads of configuration enabled.

Currently it's not so it is not an issue but adding it for future release so it continues to work if someone enables hot reloads of configuration.

- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
