### PR TITLE
Bump Telegraf image to 1.22

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -216,7 +216,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -377,7 +377,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -492,7 +492,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -543,7 +543,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -636,7 +636,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -693,8 +693,8 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
-					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}},{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},

--- a/handler_test.go
+++ b/handler_test.go
@@ -216,7 +216,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -377,7 +377,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -492,7 +492,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -543,7 +543,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"750m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -636,7 +636,7 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},
@@ -693,8 +693,8 @@ func Test_podInjector_Handle(t *testing.T) {
 				Patches: []string{
 					`{"op":"add","path":"/metadata/creationTimestamp"}`,
 					`{"op":"add","path":"/spec/containers/0/resources","value":{}}`,
-					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
-					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.19","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/1","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-config"}]}}`,
+					`{"op":"add","path":"/spec/containers/2","value":{"command":["telegraf","--config","/etc/telegraf/telegraf.conf"],"env":[{"name":"NODENAME","valueFrom":{"fieldRef":{"fieldPath":"spec.nodeName"}}}],"image":"docker.io/library/telegraf:1.22.3","name":"telegraf-istio","resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"10m","memory":"10Mi"}},"volumeMounts":[{"mountPath":"/etc/telegraf","name":"telegraf-istio-config"}]}}`,
 					`{"op":"add","path":"/spec/volumes","value":[{"name":"telegraf-config","secret":{"secretName":"telegraf-config-simple"}},{"name":"telegraf-istio-config","secret":{"secretName":"telegraf-istio-config-simple"}}]}`,
 					`{"op":"add","path":"/status","value":{}}`,
 				},

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 )
 
 const (
-	defaultTelegrafImage  = "docker.io/library/telegraf:1.19"
+	defaultTelegrafImage  = "docker.io/library/telegraf:1.22.3"
 	defaultRequestsCPU    = "10m"
 	defaultRequestsMemory = "10Mi"
 	defaultLimitsCPU      = "200m"

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -38,7 +37,7 @@ var (
 )
 
 const (
-	defaultTelegrafImage  = "docker.io/library/telegraf:1.22.3"
+	defaultTelegrafImage  = "docker.io/library/telegraf:1.22"
 	defaultRequestsCPU    = "10m"
 	defaultRequestsMemory = "10Mi"
 	defaultLimitsCPU      = "200m"

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -450,7 +450,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -576,7 +576,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -623,7 +623,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -670,7 +670,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -768,7 +768,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf-istio
     resources:
       limits:
@@ -898,7 +898,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -919,7 +919,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf-istio
     resources:
       limits:
@@ -972,7 +972,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1021,7 +1021,7 @@ spec:
     - secretRef:
         name: mysecret
         optional: true
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1070,7 +1070,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1117,7 +1117,7 @@ spec:
           fieldPath: spec.nodeName
     - name: STACK_VERSION
       value: "1.0"
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1167,7 +1167,7 @@ spec:
         configMapKeyRef:
           key: application.version
           name: configmap-name
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1217,7 +1217,7 @@ spec:
         secretKeyRef:
           key: user.password
           name: app-secret
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources:
       limits:
@@ -1270,7 +1270,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.22.3
+    image: docker.io/library/telegraf:1.22
     name: telegraf
     resources: {}
     volumeMounts:

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -450,7 +450,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -576,7 +576,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -623,7 +623,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -670,7 +670,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -768,7 +768,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf-istio
     resources:
       limits:
@@ -898,7 +898,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -919,7 +919,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf-istio
     resources:
       limits:
@@ -972,7 +972,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1021,7 +1021,7 @@ spec:
     - secretRef:
         name: mysecret
         optional: true
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1070,7 +1070,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1117,7 +1117,7 @@ spec:
           fieldPath: spec.nodeName
     - name: STACK_VERSION
       value: "1.0"
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1167,7 +1167,7 @@ spec:
         configMapKeyRef:
           key: application.version
           name: configmap-name
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1217,7 +1217,7 @@ spec:
         secretKeyRef:
           key: user.password
           name: app-secret
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources:
       limits:
@@ -1270,7 +1270,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-    image: docker.io/library/telegraf:1.19
+    image: docker.io/library/telegraf:1.22.3
     name: telegraf
     resources: {}
     volumeMounts:


### PR DESCRIPTION
Bump Telegraf image to 1.22

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
