### PR TITLE
chore(scripts): commit with --signoff for community-operators release

### DIFF
--- a/scripts/release/update-community-operators.bash
+++ b/scripts/release/update-community-operators.bash
@@ -38,7 +38,7 @@ main() {
 
   cd "${COMMUNITY_OPERATORS_PATH}"
   git add "${OPERATOR_PATH}/${version}"
-  git commit -m "operators telegraf-operator (${version})"
+  git commit -m "operators telegraf-operator (${version})" --signoff
 }
 
 main "$@"


### PR DESCRIPTION
Automates the signoff of commit for community-operators, which caused PRs to fail CI in the past

_Describe your proposed changes here._

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
