### PR TITLE
feat: support extra volume mounts, incloude support multi-volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Additional pod annotations that can be used to configure the Telegraf sidecar:
 - `telegraf.influxdata.com/requests-memory` : allows specifying resource requests for memory
 - `telegraf.influxdata.com/limits-cpu` : allows specifying resource limits for CPU
 - `telegraf.influxdata.com/limits-memory` : allows specifying resource limits for memory
+- `telegraf.influxdata.com/volume-mounts` : allows specifying extra volumes mount into the telegraf sidecar, the value should be json formatted, eg: {"volumeName": "mountPath"}
 
 
 ##### Example of extra additional options
@@ -298,6 +299,7 @@ spec:
         telegraf.influxdata.com/env-configmapkeyref-REDIS_SERVER: configmap-name.redis.url
         telegraf.influxdata.com/env-secretkeyref-PASSWORD: app-secret.redis.password
         telegraf.influxdata.com/env-literal-VERSION: "1.0"
+        telegraf.influxdata.com/volume-mounts: {"xxx-3080bfa7-log":"/opt/xxx/log"}
         telegraf.influxdata.com/inputs: |+
           [[inputs.redis]]
             servers = ["$REDIS_SERVER"]

--- a/sidecar.go
+++ b/sidecar.go
@@ -390,7 +390,7 @@ func (h *sidecarHandler) parseCustomOrDefaultQuantity(result corev1.ResourceList
 // parseCustomTelegrafVolumeMounts parses custom volumeMounts from annotations, 
 // telegrafVolumeMount should be json formatted, eg: {"volumeName": "mountPath"}
 // default is empty string.
-func (h *sidecarHandler) parseCustomTelegrafVolumeMounts(volumeMounts map[string]string, telegrafVolumeMount string) (err error) {
+func (h *sidecarHandler) parseCustomTelegrafVolumeMounts(volumeMounts *map[string]string, telegrafVolumeMount string) (err error) {
 	if telegrafVolumeMount != "" {
 		if err = json.Unmarshal([]byte(telegrafVolumeMount), volumeMounts); err != nil {
 			return err
@@ -456,7 +456,7 @@ func (h *sidecarHandler) newContainer(pod *corev1.Pod, containerName string) (co
 	if err := h.parseCustomOrDefaultQuantity(resourceLimits, "memory", telegrafLimitsMemory, h.LimitsMemory); err != nil {
 		return corev1.Container{}, err
 	}
-	if err := h.parseCustomTelegrafVolumeMounts(volumeMounts, telegrafVolumeMounts); err != nil {
+	if err := h.parseCustomTelegrafVolumeMounts(&volumeMounts, telegrafVolumeMounts); err != nil {
 		return corev1.Container{}, err
 	}
 

--- a/sidecar.go
+++ b/sidecar.go
@@ -70,7 +70,7 @@ const (
 	TelegrafLimitsCPU = "telegraf.influxdata.com/limits-cpu"
 	// TelegrafLimitsMemory allows specifying custom memory resource limits
 	TelegrafLimitsMemory = "telegraf.influxdata.com/limits-memory"
-	// TelegrafVolumeMounts allows specifying custom volumes to mount on telegraf sidecar
+	// TelegrafVolumeMounts allows specifying custom extra volumes to mount on telegraf sidecar, should be json formatted, eg: {"volumeName": "mountPath"}
 	TelegrafVolumeMounts = "telegraf.influxdata.com/volume-mounts"
 	telegrafSecretInfix  = "config"
 


### PR DESCRIPTION
Closes #103

_Describe your proposed changes here._

**add new Annotation**: **"telegraf.influxdata.com/volume-mounts"**
the above TelegrafVolumeMounts Annotation allows specifying custom extra volumes to mount on telegraf sidecar, should be json formatted, eg: {"volumeName": "mountPath"}
`telegraf.influxdata.com/volume-mounts: {"xxx-3080bfa7-log":"/opt/xxx/log"}`

also, it can support multi-volume mount, eg:
```
telegraf.influxdata.com/volume-mounts: {"xxx-3080bfa7-log":"/opt/xxx/log","xxx-3080bfa7-conf":"/opt/xxx/conf"}
```

**Prerequisites**：
**the extra-volume must already existed in the pod,**
the volume-mounts annotation just told telegraf-operator to mount the exist volume into telegraf sidecar container's some direction.

I have tested in our environment.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
