### PR TITLE
fix race condition with statefulset pod recreation startup failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v24.0.9+incompatible // indirect
+	github.com/docker/docker v20.10.17+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v24.0.9+incompatible h1:HPGzNmwfLZWdxHqK9/II92pyi1EpYKsAqcl4G0Of9v0=
-github.com/docker/docker v24.0.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=
+github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/sidecar_test.go
+++ b/sidecar_test.go
@@ -181,8 +181,8 @@ func Test_assembleConf(t *testing.T) {
 			wantConfig: `
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:6060/metrics"]
-  
-  
+
+
 
 `,
 		},
@@ -198,8 +198,8 @@ func Test_assembleConf(t *testing.T) {
 			wantConfig: `
 [[inputs.prometheus]]
   urls = ["http://127.0.0.1:6060/metrics", "http://127.0.0.1:8086/metrics"]
-  
-  
+
+
 
 `,
 		},
@@ -463,6 +463,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/class: default
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -508,6 +510,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/image: docker.io/library/telegraf:1.11
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -589,6 +593,8 @@ metadata:
     telegraf.influxdata.com/requests-cpu: 100m
     telegraf.influxdata.com/requests-memory: 100Mi
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -636,6 +642,8 @@ metadata:
     telegraf.influxdata.com/limits-cpu: 750m
     telegraf.influxdata.com/requests-cpu: 100x
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -683,6 +691,8 @@ metadata:
     telegraf.influxdata.com/limits-cpu: 750m
     telegraf.influxdata.com/requests-cpu: 100x
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -736,6 +746,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/class: default
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - image: alpine:latest
@@ -759,6 +771,8 @@ metadata:
   annotations:
     sidecar.istio.io/status: dummy
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers: null
 status: {}
@@ -781,6 +795,8 @@ metadata:
   annotations:
     sidecar.istio.io/status: dummy
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -836,6 +852,8 @@ metadata:
     telegraf.influxdata.com/istio-requests-cpu: 250m
     telegraf.influxdata.com/istio-requests-memory: 200Mi
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -923,6 +941,8 @@ metadata:
     telegraf.influxdata.com/requests-cpu: 150m
     telegraf.influxdata.com/requests-memory: 100Mi
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1002,6 +1022,8 @@ metadata:
   annotations:
     sidecar.istio.io/status: dummy
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - image: alpine:latest
@@ -1028,6 +1050,8 @@ metadata:
   annotations:
     sidecar.istio.io/status: dummy
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1077,6 +1101,8 @@ metadata:
     sidecar.istio.io/status: dummy
     telegraf.influxdata.com/class: default
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1149,6 +1175,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/class: default
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1196,6 +1224,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/secret-env: mysecret
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1245,6 +1275,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/env-fieldref-NAMESPACE: metadata.namespace
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1294,6 +1326,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/env-literal-STACK_VERSION: "1.0"
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1341,6 +1375,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/env-configmapkeyref-VERSION: configmap-name.application.version
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1391,6 +1427,8 @@ metadata:
   annotations:
     telegraf.influxdata.com/env-secretkeyref-PASSWORD: app-secret.user.password
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1449,6 +1487,8 @@ metadata:
     telegraf.influxdata.com/requests-cpu: ""
     telegraf.influxdata.com/requests-memory: ""
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1495,6 +1535,8 @@ metadata:
     telegraf.influxdata.com/class: default
     telegraf.influxdata.com/volume-mounts: '{"emptydir":"/mnt/empty"}'
   creationTimestamp: null
+  name: myname
+  namespace: mynamespace
 spec:
   containers:
   - command:
@@ -1566,7 +1608,10 @@ status: {}
 				Logger:                      testr.New(t),
 			}
 
-			result, err := handler.addSidecars(tt.pod, "myname", "mynamespace")
+			tt.pod.Name = "myname"
+			tt.pod.Namespace = "mynamespace"
+
+			result, err := handler.addSidecars(tt.pod)
 			if err != nil {
 				t.Errorf("unexpected error adding to sidecar: %v", err)
 			}


### PR DESCRIPTION
Closes #137

Resolve issue where StatefulSet pods in particular get caught in a race condition when their pods are recreated. There are a few ways to deal with this, but in this case I decided the easiest way would be to check if the pod is owned by a StatefulSet when it's created, and to append a random 5 character string to the end of the secret name.

This required some changes to the delete logic. Instead of assuming the secret name based on the pod name the updated logic gets the secret names from the volume list in the delete admission request.

- [x] Signed the [InfluxData CLA](https://www.influxdata.com/legal/cla/)
  ([if necessary](https://github.com/influxdata/telegraf-operator/blob/master/CONTRIBUTING.md#sign-the-influxdata-cla))
- [x] Tests pass (no build errors)
- [x] Rebased/mergeable
